### PR TITLE
feat(PAL): requestAnimationFrame and performance APIs

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -17,6 +17,7 @@ gulp.task('build-index', function(){
   var files = [
     'function-name.js',
     'class-list.js',
+    'performance.js',
     'custom-event.js',
     'element-matches.js',
     'feature.js',

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import {_ensureFunctionName} from './function-name';
 import {_ensureHTMLTemplateElement} from './html-template-element';
 import {_ensureElementMatches} from './element-matches';
 import {_ensureClassList} from './class-list';
+import {_ensurePerformance} from './performance';
 
 let isInitialized = false;
 
@@ -25,6 +26,7 @@ export function initialize(): void {
   _ensureHTMLTemplateElement();
   _ensureElementMatches();
   _ensureClassList();
+  _ensurePerformance();
 
   initializePAL((platform, feature, dom) => {
     Object.assign(platform, _PLATFORM);

--- a/src/performance.js
+++ b/src/performance.js
@@ -1,0 +1,27 @@
+export function _ensurePerformance(): void {
+  // performance polyfill. Copied from https://gist.github.com/paulirish/5438650
+
+  // https://gist.github.com/paulirish/5438650
+  // @license http://opensource.org/licenses/MIT
+  // copyright Paul Irish 2015
+
+  if ("performance" in window == false) {
+    window.performance = {};
+  }
+
+  Date.now = (Date.now || function () {  // thanks IE8
+    return new Date().getTime();
+  });
+
+  if ("now" in window.performance == false) {
+    var nowOffset = Date.now();
+
+    if (performance.timing && performance.timing.navigationStart) {
+      nowOffset = performance.timing.navigationStart
+    }
+
+    window.performance.now = function now() {
+      return Date.now() - nowOffset;
+    }
+  }
+}

--- a/src/platform.js
+++ b/src/platform.js
@@ -6,5 +6,9 @@ export const _PLATFORM = {
   },
   removeEventListener(eventName: string, callback: Function, capture: boolean): void {
     this.global.removeEventListener(eventName, callback, capture);
+  },
+  performance: window.performance,
+  requestAnimationFrame(callback: Function): number {
+    return this.global.requestAnimationFrame(callback);
   }
 };


### PR DESCRIPTION
@EisenbergEffect I didn't add a polyfill- was thinking we'd add instructions to the steps to make Aurelia work with IE9:

* [`requestAnimationFrame` polyfill](https://github.com/julienetie/request-frame)
* [performance polyfill](https://gist.github.com/paulirish/5438650)

What do you think?