### PR TITLE
fix htmlTemplateElement test

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -9,7 +9,9 @@ _FEATURE.scopedCSS = (function() {
 })();
 
 _FEATURE.htmlTemplateElement = (function() {
-  return 'content' in document.createElement('template');
+  var d = document.createElement("div");
+  d.innerHTML = "<template></template>";
+  return 'content' in d.children[0];
 })();
 
 _FEATURE.mutationObserver = (function() {


### PR DESCRIPTION
for behavior I observed in IE11.
no idea if this breaks it for other browsers, but htmlTemplateElement should be false for IE11, and the existing test returns true.

is for issue #9 