### PR TITLE
fix(all): do not throw when globals are not defined

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -6,8 +6,8 @@ let shadowPoly = window.ShadowDOMPolyfill || null;
 * Represents the core APIs of the DOM.
 */
 export const _DOM = {
-  Element: Element,
-  SVGElement: SVGElement,
+  Element: typeof Element !== 'undefined' && Element,
+  SVGElement: typeof SVGElement !== 'undefined' && SVGElement,
   boundary: 'aurelia-dom-boundary',
   addEventListener(eventName: string, callback: Function, capture?: boolean): void {
     document.addEventListener(eventName, callback, capture);

--- a/src/feature.js
+++ b/src/feature.js
@@ -1,17 +1,17 @@
 export const _FEATURE = {};
 
 _FEATURE.shadowDOM = (function() {
-  return !!HTMLElement.prototype.attachShadow;
+  return typeof HTMLElement !== 'undefined' && !!HTMLElement.prototype.attachShadow;
 })();
 
 _FEATURE.scopedCSS = (function() {
-  return 'scoped' in document.createElement('style');
+  return typeof document !== 'undefined' && 'scoped' in document.createElement('style');
 })();
 
 _FEATURE.htmlTemplateElement = (function() {
-  return 'content' in document.createElement('template');
+  return typeof document !== 'undefined' && 'content' in document.createElement('template');
 })();
 
 _FEATURE.mutationObserver = (function() {
-  return !!(window.MutationObserver || window.WebKitMutationObserver);
+  return typeof window !== 'undefined' && !!(window.MutationObserver || window.WebKitMutationObserver);
 })();

--- a/src/platform.js
+++ b/src/platform.js
@@ -1,13 +1,13 @@
 export const _PLATFORM = {
-  location: window.location,
-  history: window.history,
+  location: typeof window !== 'undefined' && window.location,
+  history: typeof window !== 'undefined' && window.history,
   addEventListener(eventName: string, callback: Function, capture: boolean): void {
     this.global.addEventListener(eventName, callback, capture);
   },
   removeEventListener(eventName: string, callback: Function, capture: boolean): void {
     this.global.removeEventListener(eventName, callback, capture);
   },
-  performance: window.performance,
+  performance: typeof window !== 'undefined' && window.performance,
   requestAnimationFrame(callback: Function): number {
     return this.global.requestAnimationFrame(callback);
   }


### PR DESCRIPTION
There is no way around aurelia-bootstrapper importing the pal-browser package. If we want to use the bootstrapper in the environment where globals like 'window' are not defined (e.g. NodeJS), we need to ensure this package does not throw any TypeErrors, even though we're not actually using any method from it in such environments.