### PR TITLE
fix(html-template-element): fix fatal error in IE11 when using webcomponents-lite

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -1,7 +1,11 @@
 export const _FEATURE = {
   shadowDOM: !!HTMLElement.prototype.attachShadow,
   scopedCSS: 'scoped' in document.createElement('style'),
-  htmlTemplateElement: 'content' in document.createElement('template'),
+  htmlTemplateElement: (function () {
+    var d = document.createElement('div');
+    d.innerHTML = '<template></template>';
+    return 'content' in d.children[0];
+  })(),
   mutationObserver: !!(window.MutationObserver || window.WebKitMutationObserver),
   ensureHTMLTemplateElement: t => t
 };


### PR DESCRIPTION
Fixes #9 and aurelia/loader#23
Code pulled from a closed PR #10 . PR was closed due to no response from original author.

Fixes a fatal error in IE11 when using the webcomponents-lite polyfill. The error is:

`Unhandled rejection TypeError: Unable to get property 'querySelectorAll' of undefined or null reference.`
